### PR TITLE
Fixed selected performance knob

### DIFF
--- a/SYNTHS/Community 1.2/Square Saw Bass.XML
+++ b/SYNTHS/Community 1.2/Square Saw Bass.XML
@@ -27,8 +27,8 @@
 	<modKnobs>
 		<modKnob controlsParam="pan" />
 		<modKnob controlsParam="volumePostFX" />
-		<modKnob controlsParam="bass" />
-		<modKnob controlsParam="treble" />
+		<modKnob controlsParam="lpfResonance" />
+		<modKnob controlsParam="lpfFrequency" />
 		<modKnob controlsParam="env1Release" />
 		<modKnob controlsParam="env1Attack" />
 		<modKnob controlsParam="delayFeedback" />


### PR DESCRIPTION
Fixed the selected performance knob on Square Saw Bass, also removed MPE from the name as I never tested it with an MPE controller so not really sure it should be labeled as such.