### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # deluge-community-preset-pack-1.2  
 **Download**: Click the green [<> Code] button in the top right! Then click Download Zip!  
 
-Deluge Community Firmware 1.2 Preset Competition Results! This set of presets were submitted for a preset competition for the 1.2 community firmware for the Deluge. Thank you all so much for participating! Download this repository and copy the "COMMUNITY/1.2 Presets" and "COMMUNITY/1.2 Presets B-Sides" folders to the KITS, SAMPLES, and SYNTHS folders on your SD card. The unzipped total file size is around 689 MB. You could relocate the .XML files in the KITS and SYNTHS folders to wherever you'd like, but the SAMPLES folders need to be located at `SAMPLES/COMMUNITY/1.2 Presets` and `SAMPLES/COMMUNITY/1.2 Presets B-Sides` to keep the file paths in the .XMLs correct. You SD card should end up looking something like the following:   
+Deluge Community Firmware 1.2 Preset Competition Results! This set of presets were submitted for a preset competition for the 1.2 community firmware for the Deluge. Thank you all so much for participating! Download this repository and copy the "COMMUNITY/1.2 Presets" and "COMMUNITY/1.2 Presets B-Sides" folders found in the KITS, SAMPLES, and SYNTHS folders and paste them into their respective KITS, SAMPLES, and SYNTHS folders on your SD card. The unzipped total file size is around 689 MB. You could relocate the .XML files in the KITS and SYNTHS folders to wherever you'd like, but the SAMPLES folders need to be located at `SAMPLES/COMMUNITY/1.2 Presets` and `SAMPLES/COMMUNITY/1.2 Presets B-Sides` to keep the file paths in the .XMLs correct. You SD card should end up looking something like the following:   
 
 KITS/COMMUNITY/1.2 Presets/  
 KITS/COMMUNITY/1.2 Presets B-Sides/  
@@ -66,7 +66,7 @@ Edit this README to add your own tips, tricks, and trivia!
 | 12 | MPE Wood Pluck | Too Mere | Lead, MPE |
 | 13 | Joey's Kalimba | Bay Mud | Arp, Multisample |
 | 14 | Wall of Static | ok reza | Lead |
-| 15 | Mpe Desert Strata | James MacAulay | MPE, Pad |
+| 15 | MPE Desert Strata | James MacAulay | MPE, Pad |
 | 16 | Dark | Labyrinth of Spirits | Multisample |
 | 17 | Worn Baby Grand | ok reza | Multisample |
 | 18 | 12 Metalliche | Ossimuratore | DX7 |
@@ -119,7 +119,7 @@ Edit this README to add your own tips, tricks, and trivia!
 | 65 | Stellar | Kelvin T | Lead |
 | 66 | Rusty Blade | Labyrinth of Spirits | Multisample, Lead |
 | 67 | Mellow Bass Pluck | Labyrinth of Spirits | Multisample, Bass |
-| 68 | Mpe Fm Growler | James MacAulay | MPE, Pad |
+| 68 | MPE FM Growler | James MacAulay | MPE, Pad |
 | 69 | Boombass 2 MS | Marcus Knapp | Multisample, Bass |
 | 70 | Crumbling Pad | Mark Young | Pad, FX |
 | 71 | Crafting Bass | Balistix | Bass, Lead |
@@ -162,7 +162,7 @@ Edit this README to add your own tips, tricks, and trivia!
 | 3 | Mean Pluck | ok reza | Lead |
 | 4 | Basic Bass | macMOE | Bass |
 | 5 | Classic Pad | Whispering Cosmos | Pad |
-| 6 | A Busted Sqb | shoshin | Pad |
+| 6 | A Busted SQB | shoshin | Pad |
 | 7 | Rubberdemon | postsolarpunk | Bass, DX7 |
 | 8 | J6 Pad | Whispering Cosmos | Pad |
 | 9 | UK Dub Siren | ok reza | FX |
@@ -178,7 +178,7 @@ Edit this README to add your own tips, tricks, and trivia!
 | 19 | Sirin Wah | Alexander Lane | Bass, Multisample |
 | 20 | A SCW 02 | shoshin | Lead |
 | 21 | Slow Hula Hoop | Bay Mud | Pad |
-| 22 | Giant Robot | worker gray | Bass |
+| 22 | Giant Robot FM | worker gray | Bass |
 | 23 | Kirk | Kelvin T | Lead |
 | 24 | Working Engine | Balistix | FX, Lead |
 | 25 | Stub | Kelvin T | Lead |
@@ -189,16 +189,16 @@ Edit this README to add your own tips, tricks, and trivia!
 | 30 | Undulating Drone | Whispering Cosmos | Pad |
 | 31 | Drop | Balistix | FX, Lead |
 | 32 | AnalogVoice | TerraShips | Lead |
-| 33 | Fm Leadandbass | macMOE | Lead, Bass |
+| 33 | FM Leadandbass | macMOE | Lead, Bass |
 | 34 | Mouse Tail | Balistix | Lead |
 | 35 | Low Drone Bass | Whispering Cosmos | Bass, Pad |
 | 36 | A Ring Bass | shoshin | Bass, Lead |
 | 37 | Ample Vocal Pad | Whispering Cosmos | Pad |
-| 38 | Schizophonyx | worker gray | FX, Lead |
+| 38 | Schizophonyx RM | worker gray | FX, Lead |
 | 39 | MPE Rich Saw Bass | Ted Wright | MPE |
-| 40 | Celestial | worker gray | Lead |
+| 40 | Celestial SU | worker gray | Lead |
 | 41 | FM Hammer String | shoshin | Lead |
-| 42 | 8 O Clock | Balistix | Lead |
+| 42 | 8 O'Clock | Balistix | Lead |
 | 43 | Wind Whistle | Whispering Cosmos | Pad, FX |
 | 44 | Pad Darker Pad | TerraShips | Pad |
 | 45 | Jupo Pad Lead | Alexander Lane | Lead, Pad |
@@ -213,23 +213,23 @@ Edit this README to add your own tips, tricks, and trivia!
 | 54 | Distorted Bass | Alexander Lane | Bass |
 | 55 | A FM Bass Funk | shoshin | Bass |
 | 56 | BUSTED MF | shoshin | Pad |
-| 57 | Pakmahn | worker gray | Lead |
+| 57 | Pakmahn SU | worker gray | Lead |
 | 58 | Simple Distorted Bass | sumedokin | Bass |
 | 59 | Fuzzring | nilc | Bass |
 | 60 | Cornwall | sumedokin | FX |
 | 61 | Everything | Alexander Lane | Lead, Pad |
 | 62 | Thunder | sumedokin | FX |
-| 63 | 1994 | worker gray | Lead |
+| 63 | 1994 SU | worker gray | Lead |
 | 64 | Hollowring | nilc | Lead |
 | 65 | Flea Circuits | worker gray | Lead |
 | 66 | Throaty | sumedokin | Bass |
-| 67 | Bad Zwirlz | worker gray | Bass |
-| 68 | Behind Bar | Kelvin T | Lead |
+| 67 | Bad Zwirlz SU | worker gray | Bass |
+| 68 | BehindBar Lead | Kelvin T | Lead |
 | 69 | Oimp | nilc | Lead |
-| 70 | 80s Ffunk | worker gray | Lead |
+| 70 | 80's Ffunk | worker gray | Lead |
 | 71 | Brzcrtch | nilc | Pad |
 | 72 | Tension | sumedokin | Lead |
-| 73 | Sik | worker gray | Bass |
+| 73 | Sik RM | worker gray | Bass |
 | 74 | Analohania | ElVicente | Lead |
 | 75 | Bubbley | ElVicente | Lead |
 | 76 | Exprestrings | ElVicente | Pad, Lead |


### PR DESCRIPTION
further clarified instructions for copying presets/samples

made edits to preset title's based on how they are titled on the deluge
for example. submitter worker gray seems to have appended SU (subtractive) RM (ringmod) FM (freq modulation), etc to the end of their preset names